### PR TITLE
Allow stdin for pdf2printable

### DIFF
--- a/libfuncs
+++ b/libfuncs
@@ -1,5 +1,6 @@
 LIB(poppler, "libpoppler-glib.so.8");
 FUNC(poppler, PopplerDocument*, poppler_document_new_from_file, const char*, const char*, GError**);
+FUNC(poppler, PopplerDocument*, poppler_document_new_from_fd, int, const char*, GError**);
 FUNC(poppler, int, poppler_document_get_n_pages, PopplerDocument*);
 FUNC(poppler, PopplerPage*, poppler_document_get_page, PopplerDocument*, int);
 FUNC(poppler, void, poppler_page_get_size, PopplerPage*, double*, double*);

--- a/pdf2printable_main.cpp
+++ b/pdf2printable_main.cpp
@@ -6,7 +6,7 @@
 #include "argget.h"
 
 #define HELPTEXT "Options from 'resolution' and onwards only affect raster output formats.\n" \
-                 "Use \"-\" as filename for stdout."
+                 "Use \"-\" as filename for stdin/stdout."
 
 inline void print_error(std::string hint, std::string argHelp)
 {


### PR DESCRIPTION
This adds a minimum version of Poppler 21.12, and (another?) usage of POSIX... but all in all that feels tolerable.